### PR TITLE
Components page UX fixes/adjustments

### DIFF
--- a/web-frontend/assets/js/custom/admin/components.js
+++ b/web-frontend/assets/js/custom/admin/components.js
@@ -1,5 +1,9 @@
 var component_data = [];
 
+/* Get params from URL of current Page */
+let url_obj = new URL((window.location.href).toLowerCase());
+let components_count = url_obj.searchParams.get("size") || 1;
+
 /* CALLBACK FUNCTIONS */
 const removeTab = (event) => {
     let remove_btn      = event.target;
@@ -47,7 +51,9 @@ const addTab = (component_item, component_id) => {
         description: ""
     }
 
-    component_item.querySelector(".tab_list").prepend(tab_clone);
+    /* Insert new tab before the add tab button */
+    let add_tab_btn = document.querySelector('[data-component-id="'+component_id+'"]').querySelector('.add_tab')
+    component_item.querySelector(".tab_list").insertBefore(tab_clone, add_tab_btn);
 
     tab_pane_clone.querySelector(".update_tab_form .title_tab_input").addEventListener("blur", (event) => {
         let tab_title_data = event.target.value;
@@ -117,7 +123,11 @@ const addComponentItem = () => {
     });
 
     tab_name.addEventListener("click", (event) => fetchSelectedTabDetails(event, random_component_id, random_tab_id));
-    tab_name.click();
+
+
+    setTimeout(() => {
+        tab_name.click();
+    }, 400);
 };
 
 const renderRedactorX = (params) => {
@@ -142,11 +152,33 @@ const updateSectionTitle = () => {
     section_title.style.width = section_title.value.length * 11.5 + "px";
 }
 
+/* Hide/Unhide Comments section */
+const toggleComments = (event)=> {
+    if(event.target.classList.contains("allow_comments")){
+        if(event.target.checked){
+            event.target.closest("div").querySelector(".input_field").removeAttribute("hidden");
+        }
+        else{
+            event.target.closest("div").querySelector(".input_field").setAttribute("hidden", "hidden");
+        }
+    }
+}
+
 updateSectionTitle();
 
 /* EVENTS */
+document.addEventListener("click", toggleComments);
 document.getElementById("add_component").addEventListener("click", addComponentItem);
 document.getElementById("section_title").addEventListener("keyup", updateSectionTitle);
 document.querySelector(".title_block button").addEventListener("click", () => {
    window.location.href = "/web-frontend/views/admin/component_preview.html";
+});
+
+
+$(function(){
+    /* Onload focus Description textarea if 0 size */
+    if(components_count < 1){
+        document.getElementById("add_component").click();
+        document.getElementById("section_details").focus();
+    }
 });

--- a/web-frontend/views/admin/components.html
+++ b/web-frontend/views/admin/components.html
@@ -11,6 +11,8 @@
     <!-- CONSTANTS -->
     <script src="../../assets/js/constans.js"></script>
 
+    <script src="https://code.jquery.com/jquery-3.6.0.js"></script>
+
     <!-- CUSTOM JS -->
     <script>
         let current_js  = "../../assets/js/custom/admin/components.js";
@@ -26,8 +28,8 @@
     <section id="component_wrapper">
         <div id="left_panel">
             <ul class="breadcrumbs_block">
-                <li><a href="/web-frontend/views/admin/docs.html"><span class="breadcrumbs_icon"></span> Documentations</a></li>
-                <li><a href="#"><span class="breadcrumbs_icon section_icon"></span> Engineering Guide</a></li>
+                <li><a href="/web-frontend/views/admin/docs.html?size=7"><span class="breadcrumbs_icon"></span> Documentations</a></li>
+                <li><a href="/web-frontend/views/admin/sections.html?size=7"><span class="breadcrumbs_icon section_icon"></span> Engineering Guide</a></li>
                 <li><p><span class="breadcrumbs_icon component_icon"></span> Data Usage, Collection, and Processing</p></li>
             </ul>
 
@@ -69,7 +71,7 @@
         <div class="tab-pane fade" id="hny" role="tabpanel">
             <form action="#" class="update_tab_form" method="post">
                 <label class="input_field">
-                    <span>Titless</span>
+                    <span>Titles</span>
                     <input type="text" name="title" class="title_tab_input required_input" value="Untitled">
                 </label>
                 <textarea name="tab_description" class="tab_description_input hidden" value=""></textarea>
@@ -104,7 +106,7 @@
                     <span class="text_allow_comments">Allow comments</span>
                 </label>
 
-                <label class="input_field">
+                <label class="input_field" hidden>
                     <span>Post</span>
                     <input type="text" name="post_comment" class="post_comment" placeholder="Enter Post...">
                     <span class="char_count">0/250</span>


### PR DESCRIPTION
- (Components) Add tab should append new tabs before the add button and highlight/focus the title input of the new tab - --- (Components) Only show the Enter Post textarea when allow comments is checked 
- (Components) Onload, component should be opened already and description input is focused 
- (Components) Update breadcrumbs URLs